### PR TITLE
Filter excused absences from recent sessions

### DIFF
--- a/client/src/lib/sessionFilters.ts
+++ b/client/src/lib/sessionFilters.ts
@@ -1,0 +1,7 @@
+export type AttendanceSession = {
+  Attendance?: string | null;
+};
+
+export function shouldShowInRecentSessions(session: AttendanceSession): boolean {
+  return String(session.Attendance ?? "").trim() !== "Absent (excused)";
+}

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useEffect, useMemo, useState } from "react";
 import logoPath from "@assets/logo_1755332058201.webp";
 import scheduleIconPath from "@assets/tcScheduleIcon_1755332058202.jpg";
+import { shouldShowInRecentSessions } from "@/lib/sessionFilters";
 import {
   type BillingColumnVisibility,
   type UiPolicy,
@@ -83,6 +84,7 @@ type DashboardSession = {
   Day?: string | null;
   TimeID?: number | null;
   Time?: string | null;
+  Attendance?: string | null;
 };
 
 type BillingAccountRow = {
@@ -360,6 +362,7 @@ export default function Dashboard() {
         const d = parseSessionDate(s);
         return d !== null && d < today && d >= thirtyDaysAgo;
       })
+      .filter(shouldShowInRecentSessions)
       .sort((a, b) => sessionSortKey(b) - sessionSortKey(a))
       .slice(0, 5);
   }, [sessionsForSelected]);

--- a/server/sqlServerStorage.ts
+++ b/server/sqlServerStorage.ts
@@ -225,8 +225,11 @@ export async function getSessions(studentId: number | string) {
         CAST(s.ScheduleDate AS date) AS ScheduleDateDate,
         CONVERT(varchar(10), CAST(s.ScheduleDate AS date), 23) AS ScheduleDateISO, -- 'YYYY-MM-DD'
         s.Day AS DayRaw,
-        s.TimeID
+        s.TimeID,
+        a.Attendance AS Attendance
       FROM dpinkney_TC.dbo.tblSessionSchedule AS s
+      LEFT JOIN dpinkney_TC.dbo.tblAttendance AS a
+        ON s.ID = a.MSID
       WHERE s.StudentId1 = @sid
       ORDER BY CAST(s.ScheduleDate AS date) ASC, s.TimeID ASC
     `);
@@ -250,6 +253,7 @@ export async function getSessions(studentId: number | string) {
           Day: day ?? null,
           TimeID: row.TimeID,
           Time: timeStr ?? "Unknown",
+          Attendance: row.Attendance ?? null,
           category: !isNaN(d.getTime()) && d < new Date() ? "recent" : "upcoming",
           FormattedDate: !isNaN(d.getTime())
             ? d.toLocaleDateString("en-US", {

--- a/server/tests/recent-session-filter.unit.test.ts
+++ b/server/tests/recent-session-filter.unit.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldShowInRecentSessions } from "../../client/src/lib/sessionFilters";
+
+describe("shouldShowInRecentSessions", () => {
+  it("hides excused absences from the recent sessions card", () => {
+    expect(shouldShowInRecentSessions({ Attendance: "Absent (excused)" })).toBe(false);
+    expect(shouldShowInRecentSessions({ Attendance: "  Absent (excused)  " })).toBe(false);
+  });
+
+  it("keeps other attendance states and sessions without attendance", () => {
+    expect(shouldShowInRecentSessions({ Attendance: "Present (on time)" })).toBe(true);
+    expect(shouldShowInRecentSessions({ Attendance: "Present (came late)" })).toBe(true);
+    expect(shouldShowInRecentSessions({ Attendance: "Absent (no notice)" })).toBe(true);
+    expect(shouldShowInRecentSessions({ Attendance: null })).toBe(true);
+    expect(shouldShowInRecentSessions({})).toBe(true);
+  });
+});

--- a/server/tests/sql-server-storage-sessions.unit.test.ts
+++ b/server/tests/sql-server-storage-sessions.unit.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const inputMock = vi.hoisted(() => vi.fn());
+const queryMock = vi.hoisted(() => vi.fn());
+const requestMock = vi.hoisted(() => vi.fn(() => ({ input: inputMock, query: queryMock })));
+const getPoolMock = vi.hoisted(() => vi.fn(async () => ({ request: requestMock })));
+
+vi.mock("../db", () => ({
+  getPool: getPoolMock,
+  sql: { Int: "Int" },
+}));
+
+import { getSessions } from "../sqlServerStorage";
+
+describe("getSessions attendance data", () => {
+  beforeEach(() => {
+    inputMock.mockClear();
+    queryMock.mockReset();
+    requestMock.mockClear();
+    getPoolMock.mockClear();
+
+    queryMock.mockImplementation(async (sqlText: string) => {
+      if (sqlText.includes("FROM dpinkney_TC.dbo.tblSessionSchedule AS s")) {
+        return {
+          recordset: [
+            {
+              StudentID: 39055,
+              ScheduleDateISO: "2026-05-01",
+              DayRaw: "Friday",
+              TimeID: 101,
+              Attendance: "Absent (excused)",
+            },
+          ],
+        };
+      }
+
+      if (sqlText.includes("FROM dpinkney_TC.dbo.tblTimes")) {
+        return { recordset: [{ HHMMSS: "16:30:00" }] };
+      }
+
+      return { recordset: [] };
+    });
+  });
+
+  it("selects attendance with a left join and returns it without filtering rows", async () => {
+    const sessions = await getSessions(39055);
+
+    const sessionQuery = String(queryMock.mock.calls[0]?.[0] || "");
+    expect(sessionQuery).toContain("a.Attendance AS Attendance");
+    expect(sessionQuery).toContain("LEFT JOIN dpinkney_TC.dbo.tblAttendance AS a");
+    expect(sessionQuery).toContain("ON s.ID = a.MSID");
+    expect(sessionQuery).toContain("WHERE s.StudentId1 = @sid");
+    expect(sessionQuery).not.toContain("a.Attendance !=");
+    expect(sessionQuery).not.toContain("Absent (excused)");
+
+    expect(sessions[0]).toMatchObject({
+      StudentID: 39055,
+      ScheduleDateISO: "2026-05-01",
+      Attendance: "Absent (excused)",
+    });
+  });
+});


### PR DESCRIPTION
Enrich scheduled sessions with attendance metadata from tblAttendance using a true LEFT JOIN so future sessions and sessions without attendance rows remain visible across the dashboard.

Add a reusable recent-session filter that hides only exact Absent (excused) attendance values, preserving upcoming sessions, next-session resolution, schedule-change options, and billing account details.

Add unit coverage for the SQL shape, attendance mapping, and recent-session filtering behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recent Sessions (Last 30 Days) on the dashboard now filters out sessions marked with excused absences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->